### PR TITLE
Time-sliced map store

### DIFF
--- a/map_limit_store.go
+++ b/map_limit_store.go
@@ -1,36 +1,33 @@
 package ratelimiter
 
 import (
-	"fmt"
 	"sync"
 	"time"
 )
 
-type limitValue struct {
-	val        int64
-	lastUpdate time.Time
-}
-
 // MapLimitStore represents internal limiter data database where data are stored in golang maps
 type MapLimitStore struct {
-	data           map[string]limitValue
+	data           map[int64]map[string]int64
+	size           int
 	mutex          sync.RWMutex
 	expirationTime time.Duration
 }
 
-// NewMapLimitStore creates new in-memory data store for internal limiter data. Each element of MapLimitStore is set as expired after expirationTime from its last counter increment. Expired elements are removed with a period specified by the flushInterval argument
+// NewMapLimitStore creates new in-memory data store for internal limiter data. Elements of MapLimitStore is set as expired once beginning of their Window is twice older than expiration time. Expired elements are removed with a period specified by the flushInterval argument
 func NewMapLimitStore(expirationTime time.Duration, flushInterval time.Duration) (m *MapLimitStore) {
 	m = &MapLimitStore{
-		data:           make(map[string]limitValue),
+		data:           make(map[int64]map[string]int64),
 		expirationTime: expirationTime,
 	}
 	go func() {
 		ticker := time.NewTicker(flushInterval)
 		for range ticker.C {
 			m.mutex.Lock()
-			for key, val := range m.data {
-				if val.lastUpdate.Before(time.Now().UTC().Add(-m.expirationTime)) {
-					delete(m.data, key)
+			expirationTS := time.Now().Add(-m.expirationTime*2).UnixNano()
+			for t, timeSlice := range m.data {
+				if t < expirationTS {
+					m.size -= len(timeSlice)
+					delete(m.data, t)
 				}
 			}
 			m.mutex.Unlock()
@@ -44,19 +41,40 @@ func (m *MapLimitStore) Inc(key string, window time.Time) error {
 	m.mutex.Lock()
 	defer m.mutex.Unlock()
 
-	data := m.data[mapKey(key, window)]
-	data.val++
-	data.lastUpdate = time.Now().UTC()
-	m.data[mapKey(key, window)] = data
+	windowTS := window.UnixNano()
+	timeSlice, ok := m.data[windowTS]
+	if !ok {
+		timeSlice := map[string]int64{
+			key: 1,
+		}
+		m.data[windowTS] = timeSlice
+		m.size++
+	} else {
+		oldVal, ok := timeSlice[key]
+		if ok {
+			timeSlice[key] = oldVal + 1
+		} else {
+			timeSlice[key] = 1
+			m.size++
+		}
+	}
 	return nil
+}
+
+func (m *MapLimitStore) lookupCounter(key string, window int64) int64 {
+	timeSlice, ok := m.data[window]
+	if !ok {
+		return 0
+	}
+	return timeSlice[key]
 }
 
 // Get gets value of previous window counter and current window counter for key
 func (m *MapLimitStore) Get(key string, previousWindow, currentWindow time.Time) (prevValue int64, currValue int64, err error) {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	prevValue = m.data[mapKey(key, previousWindow)].val
-	currValue = m.data[mapKey(key, currentWindow)].val
+	prevValue = m.lookupCounter(key, previousWindow.UnixNano())
+	currValue = m.lookupCounter(key, currentWindow.UnixNano())
 	return prevValue, currValue, nil
 }
 
@@ -64,9 +82,5 @@ func (m *MapLimitStore) Get(key string, previousWindow, currentWindow time.Time)
 func (m *MapLimitStore) Size() int {
 	m.mutex.RLock()
 	defer m.mutex.RUnlock()
-	return len(m.data)
-}
-
-func mapKey(key string, window time.Time) string {
-	return fmt.Sprintf("%s_%s", key, window.Format(time.RFC3339))
+	return m.size
 }

--- a/map_limit_store_test.go
+++ b/map_limit_store_test.go
@@ -83,8 +83,8 @@ func TestMapLimitStore_Get(t *testing.T) {
 	}
 	for _, tt := range tests {
 		m := NewMapLimitStore(1*time.Minute, 10*time.Second)
-		m.data[mapKey(tt.args.key, tt.args.previousWindow)] = limitValue{val: tt.wantPrevValue}
-		m.data[mapKey(tt.args.key, tt.args.currentWindow)] = limitValue{val: tt.wantCurrValue}
+		m.data[tt.args.previousWindow.UnixNano()] = map[string]int64{tt.args.key: tt.wantPrevValue}
+		m.data[tt.args.currentWindow.UnixNano()] = map[string]int64{tt.args.key: tt.wantCurrValue}
 
 		prevVal, currVal, err := m.Get(tt.args.key, tt.args.previousWindow, tt.args.currentWindow)
 		assert.NoError(t, err)


### PR DESCRIPTION
This set of changes tries to improve MapLimitStore in order to get rid of full hash table scans in cleanup goroutine.

What's changed:
* Storage size counter is now maintained through bookkeeping to avoid iterations over time slices.
* Values are stored in tiered maps, each time slice is a separate map. It allows to expire all old values through simple deletion of old maps.
* Expiration logic was adjusted to guarantee values within expiration time will be retained. So we need to delete time slices with window which is twice older as expiration time to be sure.
* No last update time is associated with each value anymore.